### PR TITLE
chezmoi の run_onchange で Brewfile パス解決を改善

### DIFF
--- a/home/run_onchange_before_20_install-packages.sh.tmpl
+++ b/home/run_onchange_before_20_install-packages.sh.tmpl
@@ -1,6 +1,3 @@
-{{- $brewfile := printf "%s/Brewfile" .chezmoi.sourceDir -}}
-{{- $brewfile_darwin := printf "%s/Brewfile.darwin" .chezmoi.sourceDir -}}
-{{- $mise_config := printf "%s/mise.toml" .chezmoi.sourceDir -}}
 {{- $is_darwin := eq .chezmoi.os "darwin" -}}
 #!/usr/bin/env bash
 set -euo pipefail
@@ -27,28 +24,59 @@ ensure_brew_in_path() {
 run_brew_bundle() {
   local file=$1
   if [ ! -f "$file" ]; then
+    log "Brewfile が見つからないためスキップ: $file"
     return 0
   fi
   log "brew bundle --file=${file}"
   brew bundle --file="$file"
 }
 
+find_repo_root() {
+  local source_dir=$1
+
+  if [ -f "$source_dir/Brewfile" ]; then
+    printf '%s\n' "$source_dir"
+    return 0
+  fi
+
+  if [ -f "$source_dir/.chezmoiroot" ]; then
+    printf '%s\n' "$source_dir"
+    return 0
+  fi
+
+  if [ -f "$source_dir/../Brewfile" ]; then
+    printf '%s\n' "$(cd "$source_dir/.." && pwd)"
+    return 0
+  fi
+
+  printf '%s\n' "$source_dir"
+}
+
 main() {
+  local repo_root brewfile brewfile_darwin mise_config
+  repo_root="$(find_repo_root "{{ .chezmoi.sourceDir }}")"
+  brewfile="${repo_root}/Brewfile"
+  brewfile_darwin="${repo_root}/Brewfile.darwin"
+  mise_config="${repo_root}/mise.toml"
+
+  log "detected sourceDir={{ .chezmoi.sourceDir }}"
+  log "detected repo_root=${repo_root}"
+
   if ! ensure_brew_in_path; then
     log "brewが見つからないため処理をスキップします"
     exit 0
   fi
 
-  run_brew_bundle "{{ $brewfile }}"
+  run_brew_bundle "$brewfile"
 {{- if $is_darwin }}
-  run_brew_bundle "{{ $brewfile_darwin }}"
+  run_brew_bundle "$brewfile_darwin"
 {{- end }}
 
   if [ "${CHEZMOI_SKIP_MISE_INSTALL:-0}" = "1" ]; then
     log "環境変数CHEZMOI_SKIP_MISE_INSTALL=1のため mise install をスキップします"
   elif command -v mise >/dev/null 2>&1; then
-    log "mise install (config={{ $mise_config }})"
-    MISE_CONFIG_FILE="{{ $mise_config }}" mise install
+    log "mise install (config=${mise_config})"
+    MISE_CONFIG_FILE="$mise_config" mise install
   else
     log "miseが未インストールのためスキップします"
   fi


### PR DESCRIPTION
### Motivation
- 新規 mac 環境で `install.sh` を実行すると `chezmoi init --apply` 後に `brew bundle` 等が実行されずセットアップが途中終了する問題を解消するための修正です。原因は `.chezmoiroot=home` の構成で `{{ .chezmoi.sourceDir }}` が `.../home` を指し、リポジトリ直下の `Brewfile` を見つけられない点にあります。

### Description
- `home/run_onchange_before_20_install-packages.sh.tmpl` に `find_repo_root` 関数を追加し、`Brewfile` / `.chezmoiroot` の有無や親ディレクトリを確認してリポジトリルートを探索するようにしました。 
- `repo_root` を基に `brewfile` / `brewfile_darwin` / `mise_config` を動的に決定するように変更しました（固定の `{{ .chezmoi.sourceDir }}` 参照を廃止）。
- `Brewfile` 未検出時の明示ログを追加し、`sourceDir` と解決後の `repo_root` を出力して調査性を向上させました。 
- `mise install` 呼び出しでテンプレート内の直接展開から環境変数 `MISE_CONFIG_FILE="$mise_config"` の利用へ変更しました。 

### Testing
- テンプレートを簡易置換して `bash -n` による構文チェックを実行した（`sed 's/{{[^}]*}}/darwin/g' home/run_onchange_before_20_install-packages.sh.tmpl > /tmp/... && bash -n /tmp/...`）結果は成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e841b001cc83279a5b0f3be2eba8ba)